### PR TITLE
feat: redirect homepage to otownmakerspace.dk

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,19 +1,20 @@
-{{ define "main" }}
-
-{{ partial "bento_workspace.html" . }}
-
-{{ partial "events.html" . }}
-
-{{ partial "memberships.html" . }}
-
-{{ partial "bento-gallery.html" . }}
-
-{{ partial "values.html" . }}
-
-{{ partial "team.html" . }}
-
-{{ partial "code-of-conduct.html" . }}
-
-{{ partial "partners-sponsors.html" . }}
-
-{{ end }}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://otownmakerspace.dk/">
+  <link rel="canonical" href="https://otownmakerspace.dk/">
+  <meta name="robots" content="noindex">
+  <title>This site has moved</title>
+  <script>
+    // Standalone redirect: no {{ define "main" }}, so Hugo renders this file
+    // directly without baseof.html. The old homepage template is preserved
+    // alongside as layouts/index.old.html.
+    location.replace("https://otownmakerspace.dk/");
+  </script>
+</head>
+<body>
+  <p>This site has moved to
+     <a href="https://otownmakerspace.dk/">otownmakerspace.dk</a>.</p>
+</body>
+</html>

--- a/layouts/index.old.html
+++ b/layouts/index.old.html
@@ -1,0 +1,19 @@
+{{ define "main" }}
+
+{{ partial "bento_workspace.html" . }}
+
+{{ partial "events.html" . }}
+
+{{ partial "memberships.html" . }}
+
+{{ partial "bento-gallery.html" . }}
+
+{{ partial "values.html" . }}
+
+{{ partial "team.html" . }}
+
+{{ partial "code-of-conduct.html" . }}
+
+{{ partial "partners-sponsors.html" . }}
+
+{{ end }}


### PR DESCRIPTION
The Town Garage site is retired; point visitors at the O Town Makerspace site. Replace the homepage template with a standalone redirect document (meta-refresh + JS, no {{ define }} so Hugo skips baseof.html). The old homepage template is preserved as layouts/index.old.html rather than deleted.