### PR TITLE
fix: remove Hugo template delimiters from redirect comment

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <title>This site has moved</title>
   <script>
-    // Standalone redirect: no {{ define "main" }}, so Hugo renders this file
-    // directly without baseof.html. The old homepage template is preserved
-    // alongside as layouts/index.old.html.
+    // Standalone redirect page. This file intentionally defines no Hugo
+    // template blocks, so Hugo renders it directly without baseof.html.
+    // The previous homepage template is preserved as layouts/index.old.html.
     location.replace("https://otownmakerspace.dk/");
   </script>
 </head>


### PR DESCRIPTION
The homepage redirect comment literally contained {{ define "main" }}, which Hugo parses as an unclosed template action (it parses layouts/*.html before any HTML/JS context), failing the build with "unexpected EOF" and breaking the main deploy. Reword the comment to drop the delimiters.