### PR TITLE
chore: remove Google Ads tag — moved to otm-website

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -18,8 +18,6 @@ enableRobotsTXT = "true"
   # Meta data
   description = ""
   author = "Axel Soll"
-  # Google Analytics
-  googleAnalyticsID = "AW-17544583777"
   # We're using formspree.io for form handling, paste your formspree url below
   formspreeFormUrl  = "https://formspree.io/abcdefgh"
 


### PR DESCRIPTION
theotowngarage.com now 301-redirects to otownmakerspace.dk, so the Google Ads tag (AW-17544583777) belongs on the otm-website. Dropping the googleAnalyticsID param disables gtag here (the analytics.html / header.html includes are guarded by `with .Site.Params.googleAnalyticsID`, so they become no-ops).